### PR TITLE
Run Dependabot monthly with grouped PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,9 +4,16 @@ updates:
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
-      # Check for updates to GitHub Actions every week
-      interval: 'weekly'
+      interval: 'monthly'
+    groups:
+      github-actions:
+        patterns:
+          - '*'
   - package-ecosystem: gomod
     directory: '/'
     schedule:
-      interval: daily
+      interval: monthly
+    groups:
+      gomod:
+        patterns:
+          - '*'


### PR DESCRIPTION
## Summary
- Switch both `github-actions` and `gomod` ecosystems from weekly/daily to `monthly`.
- Add a catch-all `groups` block per ecosystem so updates land as a single grouped PR instead of one per dependency.

## Test plan
- [ ] Wait for next Dependabot run and confirm at most one PR per ecosystem is opened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)