### PR TITLE
Add 7-day cooldown to Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
       github-actions:
         patterns:
           - '*'
+    cooldown:
+      default-days: 7
   - package-ecosystem: gomod
     directory: '/'
     schedule:
@@ -17,3 +19,5 @@ updates:
       gomod:
         patterns:
           - '*'
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
## Summary
- Adds a `cooldown.default-days: 7` block to both Dependabot ecosystems (`github-actions`, `gomod`).
- Lets newly published versions soak for a week before Dependabot opens a PR.

## Test plan
- [ ] Dependabot picks up the new config on the next scheduled run.
- [ ] Confirm subsequent grouped PRs respect the 7-day delay (verifiable from PR creation timestamps vs upstream release dates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)